### PR TITLE
fix(ci): migrate last-week slack notifications to v3 API

### DIFF
--- a/.github/workflows/last-week.yml
+++ b/.github/workflows/last-week.yml
@@ -57,9 +57,11 @@ jobs:
         id: slack
         uses: slackapi/slack-github-action@v3.0.2
         with:
-          channel-id: "C01UGQ98P9U"
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
+              "channel": "C01UGQ98P9U",
               "text": ${{ toJSON(join(github.event.commits.*.message, '\n') || ':clock6: Scheduled') }},
               "attachments": [
                 {
@@ -98,8 +100,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@v6
@@ -167,10 +167,12 @@ jobs:
         if: always()
         uses: slackapi/slack-github-action@v3.0.2
         with:
-          update-ts: ${{ steps.slack.outputs.ts }}
-          channel-id: "C01UGQ98P9U"
+          method: chat.update
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
+              "channel": "C01UGQ98P9U",
+              "ts": "${{ steps.slack.outputs.ts }}",
               "text": ${{ toJSON(join(github.event.commits.*.message, '\n') || ':clock6: Scheduled') }},
               "attachments": [
                 {
@@ -219,5 +221,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

- Renovate bumped `slackapi/slack-github-action` to v3.0.2 but the workflow still used v1.x inputs (`channel-id`, `update-ts`, `env: SLACK_BOT_TOKEN`)
- v3 API dropped those inputs — `channel` and `ts` move into the payload JSON, `SLACK_BOT_TOKEN` becomes `token:` in `with:`, and `method:` is now required
- Updated both Slack steps in `last-week.yml` to match (start → `chat.postMessage`, end → `chat.update`)
- `jekyll.yml` was already correct

## Test plan

- [ ] Workflow run completes without "Missing input" or "Unexpected input" errors
- [ ] Slack start message appears in builds channel
- [ ] Slack message updates with final status on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)