### PR TITLE
Slim CLAUDE.md to gotchas, move architecture to docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,90 +1,18 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Jekyll blog on GitHub Pages (`https://pgmac.net.au`), with a weekly "interesting last week" post auto-generated from saved links. Full architecture: `docs/ARCHITECTURE.md`.
 
-## Overview
+## Commands
 
-This is a Jekyll-based static blog hosted on GitHub Pages at https://pgmac.net.au. The site features regular blog posts, a special "interesting last week" series that's automatically generated from saved links, and tag-based organization.
-
-## Common Commands
-
-### Local Development
 ```bash
-# Install dependencies
 bundle install
-
-# Run local development server
-bundle exec jekyll serve
-
-# Build the site (outputs to _site/)
-bundle exec jekyll build
+bundle exec jekyll serve   # local dev
+bundle exec jekyll build   # -> _site/
 ```
 
-### Weekly Content Generation
-The `.github/scripts/get_interesting_news.py` script generates weekly "interesting last week" posts:
-```bash
-# Run manually (requires environment variables)
-.github/scripts/get_interesting_news.py
-```
+Weekly script (`.github/scripts/get_interesting_news.py`) needs `consumer_key` and `access_token` (Pocket API, lowercase — not the usual `POCKET_*` shape) plus `PGLINKS_KEY` (links.pgmac.net.au).
 
-Required environment variables:
-- `consumer_key` - Pocket API consumer key
-- `access_token` - Pocket API access token
-- `PGLINKS_KEY` - API key for links.pgmac.net.au
+## Gotchas
 
-## Architecture
-
-### Content Structure
-- **Posts**: Located in `_posts/` following Jekyll naming convention `YYYY-MM-DD-title.md`
-- **Layouts**: Custom layouts in `_layouts/` including:
-  - `last-week.html` - Special layout for weekly roundup posts
-  - `post.html` - Standard blog post layout
-  - `tag_page.html` - Tag archive pages
-  - `tag_feed.xml` - RSS feeds for individual tags
-- **Includes**: Reusable components in `_includes/` (header, footer, breadcrumbs, youtube embeds, etc.)
-
-### Automated Workflows
-Two GitHub Actions workflows in `.github/workflows/`:
-
-1. **last-week.yml**: Runs weekly (Sundays at 14:01 UTC) or on-demand
-   - Executes Python script to fetch saved links from a link management API
-   - Creates a new markdown post in `_posts/` with links from the previous week
-   - Commits and pushes the new post
-   - Sends Slack notifications about build status
-
-2. **jekyll.yml**: Builds and deploys the site to GitHub Pages
-   - Triggered by pushes to master or after last-week workflow completes
-   - Runs `bundle exec jekyll build`
-   - Deploys to GitHub Pages
-   - Sends Slack notifications
-
-### Configuration
-- **_config.yml**: Main Jekyll configuration
-  - Site uses the Minima theme
-  - Plugins: jekyll-feed, jekyll-category-pages, jekyll-sitemap, jekyll-paginate
-  - Pagination set to 5 posts per page
-  - Tag pages configured with custom layouts
-
-- **_data/authors.yml**: Author information referenced in post templates via `page.author`
-
-- **_plugins/ext.rb**: Loads the jekyll-tagging plugin for tag functionality
-
-### Post Front Matter
-Standard posts use this front matter structure:
-```yaml
----
-layout: last-week  # or 'post' for regular posts
-title: Some things I found interesting from 2024-06-30 to 2024-07-07
-category: Last-Week
-tags: []
-author: pgmac
----
-```
-
-### Deployment
-The site is automatically deployed to GitHub Pages when changes are pushed to the `master` branch. The build process uses Ruby 3.1 and Jekyll 4.3.
-
-## Notes
-- Config changes require restarting the Jekyll server (not auto-reloaded)
-- The site uses kramdown for markdown processing
-- Tag pages are automatically generated via the jekyll-category-pages plugin
+- Jekyll dev server does not auto-reload `_config.yml` changes — restart it
+- `jekyll.yml` (build+deploy) fires on push to `master` **or** after `last-week.yml` finishes — a weekly post is what triggers its own deploy, there's no separate scheduled build

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,27 @@
+# Architecture
+
+## Content structure
+
+- `_posts/` — Jekyll naming convention `YYYY-MM-DD-title.md`
+- `_layouts/` — `last-week.html` (weekly roundup), `post.html` (standard), `tag_page.html`, `tag_feed.xml`
+- `_includes/` — header, footer, breadcrumbs, youtube embeds, etc.
+- `_config.yml` — Minima theme; plugins jekyll-feed, jekyll-category-pages, jekyll-sitemap, jekyll-paginate (5 posts/page)
+- `_data/authors.yml` — author info referenced via `page.author`
+- `_plugins/ext.rb` — loads jekyll-tagging
+
+## Automated workflows (`.github/workflows/`)
+
+1. **last-week.yml** — weekly (Sundays 14:01 UTC) or on-demand. Runs `.github/scripts/get_interesting_news.py` to fetch saved links, creates a new `_posts/` markdown post, commits and pushes, Slack-notifies.
+2. **jekyll.yml** — builds (Ruby 3.1, Jekyll 4.3) and deploys to GitHub Pages. Triggered by pushes to `master` **or after last-week.yml completes** — so a weekly post's own commit is what triggers its deploy, not a separate scheduled build.
+
+## Post front matter
+
+```yaml
+---
+layout: last-week  # or 'post' for regular posts
+title: Some things I found interesting from 2024-06-30 to 2024-07-07
+category: Last-Week
+tags: []
+author: pgmac
+---
+```


### PR DESCRIPTION
## Summary

- CLAUDE.md cut from 90L to gotchas + non-discoverable commands only
- Content structure, workflow list, and post front-matter template moved to new `docs/ARCHITECTURE.md`

Part of the wider Claude Code docs cleanup: pgmac-net/homelabia#151

## Test plan

- [x] `docs/ARCHITECTURE.md` matches current `_layouts/`, `_plugins/`, workflow files
- [x] Nothing load-bearing dropped from the old CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgbGfmY1Z3BopzDdsmkY52